### PR TITLE
添加static关键字给replaceArrayElements, 避免可能和其他库名字起冲突

### DIFF
--- a/YYEVA/Classes/utils/YSVideoMetalUtils.m
+++ b/YYEVA/Classes/utils/YSVideoMetalUtils.m
@@ -17,7 +17,7 @@ matrix_float3x3 kColorConversion601FullRangeMatrix = (matrix_float3x3){
 vector_float3 kColorConversion601FullRangeOffset = (vector_float3){0.5, 0.5,1};
 
 //arr0[0...(size-1)] <- arr1[0...(size-1)]
-void replaceArrayElements(float arr0[], float arr1[], int size) {
+static void replaceArrayElements(float arr0[], float arr1[], int size) {
     
     if ((arr0 == NULL || arr1 == NULL) && size > 0) {
         assert(0);


### PR DESCRIPTION
在使用库的时候，和其他库都使用了同样的方法名字， 并且本库这个方法只是使用在当前的文件上，让方法名不暴露就好，避免了冲突